### PR TITLE
Utilize reusable PR label workflow

### DIFF
--- a/.github/workflows/pull-request-label.yml
+++ b/.github/workflows/pull-request-label.yml
@@ -1,37 +1,15 @@
 name: Label Pull Request
 
 on:
-    pull_request:
-        # Only following types are handled by the action, but one can default to all as well
-        types: [opened, reopened, synchronize]
-
-permissions:
-    contents: read
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
-    configure-labels:
-        permissions:
-            issues: write
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@8edcb1bdb4e267140fa742c62e395cd74f332709
-            - name: Configure missing labels
-              env:
-                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: |
-                gh label ls --json name > labels.json
-                jq -e 'if map(select(.name | contains ("patch"))) == [] then null else "Label patch exists" end' labels.json || gh label create patch --color "006b75"
-                jq -e 'if map(select(.name | contains ("minor"))) == [] then null else "Label minor exists" end' labels.json || gh label create minor --color "fbca04"
-                jq -e 'if map(select(.name | contains ("major"))) == [] then null else "Label major exists" end' labels.json || gh label create major --color "b60205"
-    label-pr:
-        permissions:
-            contents: read
-            pull-requests: write
-        runs-on: ubuntu-latest
-        steps:
-          - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5
-            with:
-                disable-autolabeler: false
-                disable-releaser: true
-            env:
-                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  check:
+    name: "Label Pull Request"
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-pr-label-by-branch.yml@0.6.0
+    secrets: inherit # pragma: allowlist secret


### PR DESCRIPTION
Now takes advantage of the reusable workflow, which fixes private repos.